### PR TITLE
Fix Vue warnings

### DIFF
--- a/web_client/components/index/SectionLinks.vue
+++ b/web_client/components/index/SectionLinks.vue
@@ -15,10 +15,10 @@
             </h2>
             <div class="items-start justify-center custom-grid">
                 <Item
-                    class="mt-2"
                     v-for="link in links"
-                    :link="link.href"
                     :key="link.text"
+                    class="mt-2"
+                    :link="link.href"
                     >{{ link.text }}</Item
                 >
             </div>
@@ -45,7 +45,12 @@ export default {
             type: String,
             default: '',
         },
-        links: Array,
+        links: {
+            type: Array,
+            default() {
+                return []
+            },
+        },
     },
 }
 </script>

--- a/web_client/pages/index.vue
+++ b/web_client/pages/index.vue
@@ -24,8 +24,8 @@
             </div>
             <div class="flex flex-col mx-auto max-w-mobile-lg md:max-w-full">
                 <section-links
-                    imgSrc="taxes.svg"
-                    imgAlt="Filing taxes"
+                    img-src="taxes.svg"
+                    img-alt="Filing taxes"
                     header="On The Pulse"
                     :links="[
                         {
@@ -56,8 +56,8 @@
                     ]"
                 />
                 <section-links
-                    imgSrc="assistance.svg"
-                    imgAlt="Government Assistance"
+                    img-src="assistance.svg"
+                    img-alt="Government Assistance"
                     header="Benefits and Services"
                     :links="[
                         {
@@ -80,8 +80,8 @@
                     ]"
                 />
                 <section-links
-                    imgSrc="registration.svg"
-                    imgAlt="Voter Registration"
+                    img-src="registration.svg"
+                    img-alt="Voter Registration"
                     header="Elections"
                     :links="[
                         {
@@ -115,8 +115,8 @@
                     ]"
                 />
                 <section-links
-                    imgSrc="registration.svg"
-                    imgAlt="Financial"
+                    img-src="registration.svg"
+                    img-alt="Financial"
                     header="Financial"
                     :links="[
                         {


### PR DESCRIPTION
Fixes a bunch of vue warnings

```
/Users/justinchi/projects/Citizen-Center/web_client/components/index/SectionLinks.vue
  19:21  warning  Attribute "v-for" should go before "class"     vue/attributes-order
  21:21  warning  Attribute ":key" should go before ":link"      vue/attributes-order
  48:9   warning  Prop 'links' requires default value to be set  vue/require-default-prop

/Users/justinchi/projects/Citizen-Center/web_client/pages/index.vue
   27:21  warning  Attribute 'imgSrc' must be hyphenated  vue/attribute-hyphenation
   28:21  warning  Attribute 'imgAlt' must be hyphenated  vue/attribute-hyphenation
   59:21  warning  Attribute 'imgSrc' must be hyphenated  vue/attribute-hyphenation
   60:21  warning  Attribute 'imgAlt' must be hyphenated  vue/attribute-hyphenation
   83:21  warning  Attribute 'imgSrc' must be hyphenated  vue/attribute-hyphenation
   84:21  warning  Attribute 'imgAlt' must be hyphenated  vue/attribute-hyphenation
  118:21  warning  Attribute 'imgSrc' must be hyphenated  vue/attribute-hyphenation
  119:21  warning  Attribute 'imgAlt' must be hyphenated  vue/attribute-hyphenation

✖ 11 problems (0 errors, 11 warnings)
  0 errors and 10 warnings potentially fixable with the `--fix` option.
```