### PR TITLE
Keep footer at the bottom of page

### DIFF
--- a/web_client/components/FeatureTemplate.vue
+++ b/web_client/components/FeatureTemplate.vue
@@ -82,7 +82,7 @@ export default {
 
 <style>
 .feature-template {
-    min-height: 63vh;
+    min-height: 70vh;
 }
 
 .nuxt-content {


### PR DESCRIPTION
After sarah removed the footer links, footer's now "detaching" from the bottom. This pushes it down a bit further to cover most devices